### PR TITLE
Tests processes handling

### DIFF
--- a/Golem.Tests/ErrorHandlingTest.cs
+++ b/Golem.Tests/ErrorHandlingTest.cs
@@ -75,7 +75,7 @@ namespace Golem.Tests
             Assert.Empty(RunningExecutablesNames(subprocesses));
 
             var stopTask = golem.Stop();
-            Assert.Equal(GolemStatus.Stopping, await TestUtils.ReadChannel<GolemStatus?>(statusChannel));
+            Assert.Equal(GolemStatus.Stopping, await TestUtils.ReadChannel<GolemStatus?>(statusChannel, (GolemStatus? s) => s == GolemStatus.Error, 30_000));
             await stopTask;
 
             // Check if status changed from Error to Off

--- a/Golem.Tests/JobTests.cs
+++ b/Golem.Tests/JobTests.cs
@@ -65,10 +65,10 @@ namespace Golem.Tests
             _logger.LogInformation("Starting Golem");
             await golem.Start();
             // On startup Golem status goes from `Off` to `Starting`
-            Assert.Equal(GolemStatus.Starting, await ReadChannel(golemStatusChannel, (GolemStatus s) => s == GolemStatus.Off));
+            Assert.Equal(GolemStatus.Starting, await ReadChannel(golemStatusChannel, (GolemStatus s) => s == GolemStatus.Off, 30_000));
 
             // .. and then to `Ready`
-            Assert.Equal(GolemStatus.Ready, await ReadChannel(golemStatusChannel, (GolemStatus s) => s == GolemStatus.Starting));
+            Assert.Equal(GolemStatus.Ready, await ReadChannel(golemStatusChannel, (GolemStatus s) => s == GolemStatus.Starting, 30_000));
 
             // `CurrentJob` after startup, before taking any Job should be null
             Assert.Null(golem.CurrentJob);
@@ -140,10 +140,10 @@ namespace Golem.Tests
             _logger.LogInformation("Stopping Golem");
             await golem.Stop();
 
-            var stoppingStatus = await ReadChannel(golemStatusChannel, (GolemStatus status) => { return status == GolemStatus.Ready; });
+            var stoppingStatus = await ReadChannel(golemStatusChannel, (GolemStatus status) => status == GolemStatus.Ready, 30_000);
             Assert.Equal(GolemStatus.Stopping, stoppingStatus);
 
-            var offStatus = await ReadChannel(golemStatusChannel, (GolemStatus status) => { return status == GolemStatus.Ready; });
+            var offStatus = await ReadChannel(golemStatusChannel, (GolemStatus status) => status == GolemStatus.Ready, 30_000);
             Assert.Equal(GolemStatus.Off, offStatus);
         }
     }

--- a/Golem.Tests/LogFilesTest.cs
+++ b/Golem.Tests/LogFilesTest.cs
@@ -58,7 +58,7 @@ namespace Golem.Tests
             // Start app to create runtime logs
             var app = _requestor?.CreateSampleApp() ?? throw new Exception("Requestor not started yet");
             Assert.True(app.Start());
-            Job? currentJob = await ReadChannel<Job?>(jobChannel);
+            Job? currentJob = await ReadChannel<Job?>(jobChannel, timeoutMs: 30_000);
             var currentState = await ReadChannel(jobStatusChannel, (JobStatus s) => s != JobStatus.Computing, 30_000);
             await app.Stop();
 

--- a/Golem.Tests/ProviderFailureHandlingTest.cs
+++ b/Golem.Tests/ProviderFailureHandlingTest.cs
@@ -16,7 +16,6 @@ using System.Runtime.InteropServices;
 namespace Golem.Tests
 {
     public class ErrorHandlingTests : JobsTestBase
-
     {
 
         public ErrorHandlingTests(ITestOutputHelper outputHelper, GolemFixture golemFixture)

--- a/Golem.Tools/GolemRunnable.cs
+++ b/Golem.Tools/GolemRunnable.cs
@@ -35,6 +35,7 @@ namespace Golem.Tools
             if (!process.Process.HasExited)
             {
                 _golemProcess = process;
+                ChildProcessTracker.AddProcess(_golemProcess.Process);
                 return !_golemProcess.Process.HasExited;
             }
 


### PR DESCRIPTION
- Attaching processes spawned by tests/MockUI to JobObject
- Increased timeouts to avoid failures on Windows github runner
- ErrorHandlingTest change making it to not fail when Error status is set multiple times after provider process failure