### PR TITLE
Restore prev accept timeout

### DIFF
--- a/Golem.Tests/JobStatusTests.cs
+++ b/Golem.Tests/JobStatusTests.cs
@@ -20,7 +20,9 @@ namespace Golem.Tests
     {
         public JobStatusTests(ITestOutputHelper outputHelper, GolemFixture golemFixture)
             : base(outputHelper, golemFixture, nameof(JobStatusTests))
-        { }
+        {
+            Environment.SetEnvironmentVariable("DEBIT_NOTE_ACCEPTANCE_DEADLINE", "30s");
+        }
 
         [Fact]
         public async Task RequestorBreaksAgreement_KillingScript()

--- a/Golem/Yagna/Provider.cs
+++ b/Golem/Yagna/Provider.cs
@@ -223,7 +223,6 @@ namespace Golem.Yagna
 
                 var env = new Dictionary<string, string>(Env);
                 env["MIN_AGREEMENT_EXPIRATION"] = "30s";
-                env["DEBIT_NOTE_ACCEPTANCE_DEADLINE"] = "30s";
                 env["YAGNA_APPKEY"] = appKey;
 
                 ProviderProcess = await Task.Run(() => ProcessFactory.StartProcess(_yaProviderPath, arguments, env));


### PR DESCRIPTION
30s DebitNote accept timeout seems too short for scalepoint, because it may not be able to set payment accept service.