### PR TITLE
Fix usage/price conversions between double and decimals

### DIFF
--- a/GolemLib.Tests/TypesTests.cs
+++ b/GolemLib.Tests/TypesTests.cs
@@ -2,6 +2,7 @@ using GolemLib.Types;
 
 namespace GolemLib.Tests;
 
+// The following tests ensure that C# code's behavior matches Rust's one.
 public class TypesTests
 {
     [Fact]

--- a/GolemLib.Tests/TypesTests.cs
+++ b/GolemLib.Tests/TypesTests.cs
@@ -15,7 +15,7 @@ public class TypesTests
             NumRequests = 0
         };
         var usage = new GolemUsage(startPrice);
-        
+
         var price = new GolemPrice
         {
             StartPrice = 0.444m,
@@ -41,7 +41,7 @@ public class TypesTests
             NumRequests = 0
         };
         var usage = new GolemUsage(startPrice);
-        
+
         var price = new GolemPrice
         {
             StartPrice = 0.444000000000000001m,
@@ -54,5 +54,101 @@ public class TypesTests
         var reward = usage.Reward(price);
 
         Assert.Equal(0.584571m, reward);
+    }
+
+    [Fact]
+    public void GolemUsage_Reward_Round_Precision()
+    {
+        var usageVec = new GolemPrice
+        {
+            StartPrice = 1.0m,
+            EnvPerSec = 959.0184787m,
+            GpuPerSec = 0.4584724m,
+            NumRequests = 62.0m
+        };
+        var usage = new GolemUsage(usageVec);
+
+        var price = new GolemPrice
+        {
+            StartPrice = 0.0007m,
+            EnvPerSec = 0.0003m,
+            GpuPerSec = 0.0005m,
+            NumRequests = 0.000m
+        };
+
+        var reward = usage.Reward(price);
+        Assert.Equal(0.288634779809999970m, reward);
+    }
+
+    [Fact]
+    public void GolemUsage_Reward_Non_Representable_Values()
+    {
+        var usageVec = new GolemPrice
+        {
+            StartPrice = 1.0m,
+            EnvPerSec = 44.017951m,
+            GpuPerSec = 103.002864998m,
+            NumRequests = 0.0m
+        };
+        var usage = new GolemUsage(usageVec);
+
+        var price = new GolemPrice
+        {
+            StartPrice = 0.0m,
+            EnvPerSec = 0.0001m,
+            GpuPerSec = 0.00005m,
+            NumRequests = 0.0m
+        };
+
+        var reward = usage.Reward(price);
+        Assert.Equal(0.0095519383499m, reward);
+    }
+
+    [Fact]
+    public void GolemUsage_Reward_Underflow()
+    {
+        var usageVec = new GolemPrice
+        {
+            StartPrice = 1.0m,
+            EnvPerSec = 24.141030488m,
+            GpuPerSec = 0.0m,
+            NumRequests = 0.0m
+        };
+        var usage = new GolemUsage(usageVec);
+
+        var price = new GolemPrice
+        {
+            StartPrice = 0.0m,
+            EnvPerSec = 0.002m,
+            GpuPerSec = 0.008m,
+            NumRequests = 0.0m
+        };
+
+        var reward = usage.Reward(price);
+        Assert.Equal(0.048282060976m, reward);
+    }
+
+    [Fact]
+    public void GolemUsage_Reward_Overflow()
+    {
+        var usageVec = new GolemPrice
+        {
+            StartPrice = 1.0m,
+            EnvPerSec = 44.094619588m,
+            GpuPerSec = 0.0m,
+            NumRequests = 0.0m
+        };
+        var usage = new GolemUsage(usageVec);
+
+        var price = new GolemPrice
+        {
+            StartPrice = 0.0m,
+            EnvPerSec = 0.002m,
+            GpuPerSec = 0.008m,
+            NumRequests = 0.0m
+        };
+
+        var reward = usage.Reward(price);
+        Assert.Equal(0.088189239176m, reward);
     }
 }

--- a/GolemLib.sln
+++ b/GolemLib.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Golem.Package", "Golem.Pack
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleRunner", "ExampleRunner\ExampleRunner.csproj", "{35C7BEC1-FA91-4B29-9C6C-48ABA08388D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GolemLib.Tests", "GolemLib.Tests\GolemLib.Tests.csproj", "{840D9798-C88E-4120-B19C-FFE1B62CCBF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{35C7BEC1-FA91-4B29-9C6C-48ABA08388D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{35C7BEC1-FA91-4B29-9C6C-48ABA08388D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{35C7BEC1-FA91-4B29-9C6C-48ABA08388D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{840D9798-C88E-4120-B19C-FFE1B62CCBF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{840D9798-C88E-4120-B19C-FFE1B62CCBF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{840D9798-C88E-4120-B19C-FFE1B62CCBF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{840D9798-C88E-4120-B19C-FFE1B62CCBF3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GolemLib/GolemPrice.cs
+++ b/GolemLib/GolemPrice.cs
@@ -94,7 +94,7 @@ public class GolemPrice : INotifyPropertyChanged, IEquatable<GolemPrice>
         };
     }
 
-    public static GolemPrice From(decimal? InitialPrice, Dictionary<string, decimal> coeffs)
+    public static GolemPrice From(decimal? initialPrice, Dictionary<string, decimal> coeffs)
     {
         if (!coeffs.TryGetValue("ai-runtime.requests", out var numRequests))
             numRequests = 0;
@@ -103,7 +103,7 @@ public class GolemPrice : INotifyPropertyChanged, IEquatable<GolemPrice>
         if (!coeffs.TryGetValue("golem.usage.gpu-sec", out var gpuSec))
             gpuSec = 0;
 
-        var initPrice = InitialPrice ?? 0m;
+        var initPrice = initialPrice ?? 0m;
 
         return new GolemPrice
         {

--- a/GolemLib/types.cs
+++ b/GolemLib/types.cs
@@ -17,7 +17,7 @@ public class GolemUsage : GolemPrice
     // I couldn't find definite answer if C#'s `double` is IEEE-754 compliant floating number:
     // https://csharpindepth.com/Articles/FloatingPoint claims that it is, stackoverflow claimed that it isn't.
     // Still, both `double` and IEEE-754 64-bit floating numbers use 52 bits for binary significant digits,
-    // which correspond to - depending or value of the highest digits - 15 to 17 decimal digits.
+    // which correspond to - depending or value of the highest mantisse bits - 15 to 17 decimal digits.
     // Rust library `bignum` in version 0.2 currently used in `yagna` incorrectly handles the most significant
     // digits when parsing floats. In order to get the same results in Rust and C#, we need to match its behavior.
     private static decimal RustCompatibilityRound(decimal i)

--- a/GolemLib/types.cs
+++ b/GolemLib/types.cs
@@ -3,6 +3,7 @@ namespace GolemLib.Types;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
 
 using Microsoft.Extensions.Options;
 
@@ -14,8 +15,14 @@ public class GolemUsage : GolemPrice
     // according to https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
     // double precision is 15-17 digits
     // for compatibility with Rust ::std::f64::DIGITS this is hardcoded to 15
-    private const int DIGITS = 15;
-    private static decimal Round(decimal v) => Math.Round(v, DIGITS);
+    public static decimal Round(decimal v) => GolemUsage.RoundThroughDouble(v);
+
+    private static decimal RoundThroughDouble(decimal i)
+    {
+        // Print to string with exponential notation including 15 significant digits.
+        var formattedDouble = ((double)i).ToString("E15", CultureInfo.InvariantCulture);
+        return decimal.Parse(formattedDouble, System.Globalization.NumberStyles.Float);
+    }
 
     public decimal Reward(GolemPrice prices)
     {


### PR DESCRIPTION
resolves: https://github.com/golemfactory/gamerhash-facade/issues/175

> [!IMPORTANT]  
> Changes are backward compatible, but GH app must update it's GolemLib dependency, to make the difference.