### PR TITLE
Bump automatic package version to v0.2.0 (nginx)

### DIFF
--- a/scripts/automatic.ps1
+++ b/scripts/automatic.ps1
@@ -1,5 +1,5 @@
 param (
-    [string]$automatic_runtime_package_url = "https://gpu-on-golem.s3.eu-central-1.amazonaws.com/sd-webui-standalone/sd-webui-gh-v0.1.3.zip",
+    [string]$automatic_runtime_package_url = "https://gpu-on-golem.s3.eu-central-1.amazonaws.com/sd-webui-standalone/sd-webui-gh-v0.2.0.zip",
     [string]$automatic_package_dir = "package",
     [bool]$compress = 0,
     [bool]$cleanup = 0


### PR DESCRIPTION
Windows tests fail but this is also the case on the master branch right now, I've verified that there are no new failed tests.