### PR TITLE
Set payment status to Settled always when Job is paid

### DIFF
--- a/Golem/Job.cs
+++ b/Golem/Job.cs
@@ -214,8 +214,7 @@ namespace Golem.Yagna.Types
             Logger.LogInformation($"Job: {this.Id}, confirmed sum: {confirmedSum}, job expected reward: {this.CurrentReward}");
 
             // Workaround for yagna unable to change status to SETTLED when using partial payments
-            if (suggestedPaymentStatus == GolemLib.Types.PaymentStatus.Accepted
-                && this.CurrentReward == confirmedSum)
+            if (this.CurrentReward == confirmedSum)
             {
                 return IntoPaymentStatus(InvoiceStatus.SETTLED);
             }

--- a/Golem/Job.cs
+++ b/Golem/Job.cs
@@ -117,6 +117,7 @@ namespace Golem.Yagna.Types
             }
         }
 
+        public bool IsClosed { get => !Active; }
 
         public void UpdateActivityState(ActivityStatePair activityState)
         {
@@ -214,7 +215,7 @@ namespace Golem.Yagna.Types
             Logger.LogInformation($"Job: {this.Id}, confirmed sum: {confirmedSum}, job expected reward: {this.CurrentReward}");
 
             // Workaround for yagna unable to change status to SETTLED when using partial payments
-            if (this.CurrentReward == confirmedSum)
+            if (this.IsClosed && this.CurrentReward == confirmedSum)
             {
                 return IntoPaymentStatus(InvoiceStatus.SETTLED);
             }


### PR DESCRIPTION
In previous version if we were in `InvoiceSent` state, than status wouldn't be changed as long as we didn't get Invoice acceptance.