### PR TITLE
Improve yagna metrics accuracy

### DIFF
--- a/Golem.Package/Args.cs
+++ b/Golem.Package/Args.cs
@@ -5,7 +5,7 @@ public class BuildArgs
 {
     [Option('t', "target", Default = "package", Required = false, HelpText = "Directory where binaries will be generated relative to working dir")]
     public required string Target { get; set; }
-    [Option('y', "yagna-version", Default = "pre-rel-v0.16.0-preview.ai.29", Required = false, HelpText = "Yagna version github tag")]
+    [Option('y', "yagna-version", Default = "pre-rel-v0.16.0-preview.ai.42", Required = false, HelpText = "Yagna version github tag")]
     public required string GolemVersion { get; set; }
     [Option('r', "runtime-version", Default = "v0.2.5", Required = false, HelpText = "Runtime version github tag")]
     public required string RuntimeVersion { get; set; }

--- a/Golem.Tools/GolemPackageBuilder.cs
+++ b/Golem.Tools/GolemPackageBuilder.cs
@@ -18,7 +18,7 @@ namespace Golem.Tools
 {
     public class PackageBuilder
     {
-        public static string CURRENT_GOLEM_VERSION = "pre-rel-v0.16.0-preview.ai.29";
+        public static string CURRENT_GOLEM_VERSION = "pre-rel-v0.16.0-preview.ai.42";
         public static string CURRENT_RUNTIME_VERSION = "v0.2.5";
 
         internal static string InitTestDirectory(string name, bool cleanupData = true)

--- a/Golem/Yagna/YagnaService.cs
+++ b/Golem/Yagna/YagnaService.cs
@@ -165,7 +165,7 @@ namespace Golem.Yagna
                 environment = Options.YagnaApiUrl != null ? environment.WithYagnaApiUrl(Options.YagnaApiUrl) : environment;
                 environment = Options.PrivateKey != null ? environment.WithPrivateKey(Options.PrivateKey) : environment;
                 environment = Options.AppKey != null ? environment.WithAppKey(Options.AppKey) : environment;
-                environment = environment.WithMetricsGroup("GamerHash." + Options.Network.ToString());
+                environment = environment.WithMetricsGroup("GamerHash." + Options.Network.Id);
                 environment = environment.WithYaUseHttpsDnsResolver();
 
                 var args = $"service run {debugFlag}".Split();

--- a/Golem/Yagna/YagnaService.cs
+++ b/Golem/Yagna/YagnaService.cs
@@ -165,7 +165,7 @@ namespace Golem.Yagna
                 environment = Options.YagnaApiUrl != null ? environment.WithYagnaApiUrl(Options.YagnaApiUrl) : environment;
                 environment = Options.PrivateKey != null ? environment.WithPrivateKey(Options.PrivateKey) : environment;
                 environment = Options.AppKey != null ? environment.WithAppKey(Options.AppKey) : environment;
-                environment = environment.WithMetricsGroup("GamerHash");
+                environment = environment.WithMetricsGroup("GamerHash." + Options.Network.ToString());
                 environment = environment.WithYaUseHttpsDnsResolver();
 
                 var args = $"service run {debugFlag}".Split();

--- a/MockGUI/readme.md
+++ b/MockGUI/readme.md
@@ -39,7 +39,7 @@ dotnet run --project Golem.Package -- download --target modules --version pre-re
 In case of building artifacts locally you can specify `yagna` and `runtimes` versions:
 
 ```sh
-dotnet run --project Golem.Package -- build --target modules --yagna-version pre-rel-v0.16.0-preview.ai.29 --runtime-version v0.2.5
+dotnet run --project Golem.Package -- build --target modules --yagna-version pre-rel-v0.16.0-preview.ai.42 --runtime-version v0.2.5
 ```
 
 ## Running


### PR DESCRIPTION
With regard to the `group` label:
- I intentionally picked a new one that will need queries to be modified if we want to use the metrics from the older packages. I did it so that we can trust the metrics more, because right now when querying for `GamerHash` group we'd get metrics from both polygon and holesky (or whatever the testnet is). If we want to query both, we can do it, but need to opt into it by adding `or` to the query. I prefer such explicity.
- ~~I checked that GamerHash dashboards on grafana don't use `group` label - this PR won't break them (though perhaps after deploying a new package we should update the dashboards)~~
  - edit: my bad, the dashboards use it, but are also already ready for selecting other names
- I thought a little whether the name should contain currency too so that it is more similar to the metrics we collect from our requestor, but I couldn't find it anywhere in the code, so I think we should be fine without it.

I didn't get any provider logs that pushing metrics on `yagna` exit would help with, so I'll leave that for another time.